### PR TITLE
Add button interrupt for signal source toggle

### DIFF
--- a/Core/Inc/stm32f3xx_it.h
+++ b/Core/Inc/stm32f3xx_it.h
@@ -56,6 +56,7 @@ void DebugMon_Handler(void);
 void PendSV_Handler(void);
 void SysTick_Handler(void);
 /* USER CODE BEGIN EFP */
+void EXTI15_10_IRQHandler(void);
 
 /* USER CODE END EFP */
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -61,6 +61,11 @@ ADC_HandleTypeDef hadc1;
 UART_HandleTypeDef huart1;
 UART_HandleTypeDef huart2;
 
+/* Flag que define si se envían datos simulados (true)
+   o valores capturados por el ADC (false).  Se modifica
+   desde la interrupción del botón de usuario. */
+volatile bool Simulacion = false;
+
 /* USER CODE BEGIN PV */
 
 /* USER CODE END PV */
@@ -123,7 +128,6 @@ int main(void)
   /* USER CODE BEGIN 2 */
 
   /* USER CODE END 2 */
-  bool Simulacion = false; //true para simular, false para obtener datos del puerto ADC
   int nSenalesSimulacion = 2; // Número de señales simuladas simultáneas (2-4)
   WaveformType signal_types[4] = {WAVE_SINE, WAVE_SQUARE, WAVE_TRIANGLE, WAVE_SAWTOOTH};
   float angles[4] = {0};
@@ -425,6 +429,10 @@ static void MX_GPIO_Init(void)
   GPIO_InitStruct.Pull = GPIO_NOPULL;
   HAL_GPIO_Init(B1_GPIO_Port, &GPIO_InitStruct);
 
+  /* Configurar y habilitar la interrupción del botón de usuario */
+  HAL_NVIC_SetPriority(EXTI15_10_IRQn, 0, 0);
+  HAL_NVIC_EnableIRQ(EXTI15_10_IRQn);
+
   /*Configure GPIO pin : LD2_Pin */
   GPIO_InitStruct.Pin = LD2_Pin;
   GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
@@ -438,6 +446,19 @@ static void MX_GPIO_Init(void)
 }
 
 /* USER CODE BEGIN 4 */
+
+/**
+  * @brief Callback de la interrupción generada por el botón de usuario
+  *        Alterna la bandera 'Simulacion' para cambiar entre señal simulada
+  *        y lectura real del ADC.
+  */
+void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
+{
+  if (GPIO_Pin == B1_Pin)
+  {
+    Simulacion = !Simulacion;
+  }
+}
 
 /* USER CODE END 4 */
 

--- a/Core/Src/stm32f3xx_it.c
+++ b/Core/Src/stm32f3xx_it.c
@@ -199,5 +199,15 @@ void SysTick_Handler(void)
 /******************************************************************************/
 
 /* USER CODE BEGIN 1 */
+/**
+  * @brief This function handles external line[15:10] interrupts.
+  * En este proyecto se utiliza para leer el botón de usuario (B1)
+  * y alternar entre la señal simulada y la leídad del ADC.
+  */
+void EXTI15_10_IRQHandler(void)
+{
+  HAL_GPIO_EXTI_IRQHandler(B1_Pin);
+}
+
 
 /* USER CODE END 1 */


### PR DESCRIPTION
## Summary
- toggle between ADC data and simulated signal using user button
- configure NVIC for EXTI line and implement interrupt handler
- add callback that flips the simulation flag

## Testing
- `make -C Debug` *(fails: multiple target patterns)*
